### PR TITLE
Fix highlighting of comments in enum declarations

### DIFF
--- a/syntaxes/vala.tmLanguage
+++ b/syntaxes/vala.tmLanguage
@@ -620,6 +620,10 @@
 			<key>patterns</key>
 			<array>
 				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+				<dict>
 					<key>begin</key>
 					<string>\w+</string>
 					<key>beginCaptures</key>


### PR DESCRIPTION
This fixes the highlighting of comments in vala enum declarations.

Previously only a comment before the first member would be highlighted
as a comment.